### PR TITLE
Fixing screenshots on IE

### DIFF
--- a/src/main/resources/js/get-current-scrollX.js
+++ b/src/main/resources/js/get-current-scrollX.js
@@ -1,1 +1,1 @@
-return window.scrollX;
+return Math.max(document.documentElement.scrollLeft, document.body.scrollLeft);

--- a/src/main/resources/js/get-current-scrollY.js
+++ b/src/main/resources/js/get-current-scrollY.js
@@ -1,1 +1,1 @@
-Math.max(document.documentElement.scrollTop, document.body.scrollTop);
+return Math.max(document.documentElement.scrollTop, document.body.scrollTop);

--- a/src/main/resources/js/get-current-scrollY.js
+++ b/src/main/resources/js/get-current-scrollY.js
@@ -1,1 +1,1 @@
-return window.scrollY;
+Math.max(document.documentElement.scrollTop, document.body.scrollTop);


### PR DESCRIPTION
Currently when running this library with IE, the tests will crash with a null pointer exception. This is due to window.scrollX and window.scrollY not being supported in IE.

This PR fixes the problem.