### PR TITLE
Update FileUtil.java

### DIFF
--- a/src/main/java/com/assertthat/selenium_shutterbug/utils/file/FileUtil.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/utils/file/FileUtil.java
@@ -21,7 +21,14 @@ public class FileUtil {
 
     public static String getJsScript(String filePath) {
         try {
-            return IOUtils.toString(Thread.currentThread().getContextClassLoader().getResourceAsStream(filePath));
+            InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(filePath);
+            if (is == null) {
+                // This is needed to load the files in an OSGI enviroment when enclosed in a bundle
+                is = FileUtil.class.getClassLoader().getResourceAsStream(filePath);
+            }
+            // if the input stream is still null, this will avoid a non descriptive null pointer exception
+            if (is == null) new UnableTakeSnapshotException("Unable to load JS script, unable to locate resource stream.");
+            return IOUtils.toString(is);
         } catch (IOException e) {
             throw new UnableTakeSnapshotException("Unable to load JS script", e);
         }

--- a/src/main/java/com/assertthat/selenium_shutterbug/utils/file/FileUtil.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/utils/file/FileUtil.java
@@ -13,6 +13,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Created by Glib_Briia on 17/06/2016.


### PR DESCRIPTION
Update to the FileUtil to make the java script resource loading work in an OSGI environment.   Kept the original loader to ensure backwards compatibility.  Essentially checks to make sure the InputStream is found.   If not, it will try loading the resource using the proper method for an OSGI environment.   If it still is unable to load the file, it will throw an exception to avoid a non descriptive null pointer exception.