### PR TITLE
Update to Browser to Delete .png files being left in java tmp directory

### DIFF
--- a/src/main/java/com/assertthat/selenium_shutterbug/utils/web/Browser.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/utils/web/Browser.java
@@ -71,7 +71,7 @@ public class Browser {
             throw new UnableTakeSnapshotException(e);
         } finally {
 	    // add this to clean up leaving this file in the temporary directory forever...
-	    if (scrFile.exists()) {
+	    if (srcFile.exists()) {
 	       srcFile.delete();
 	    }
 	}

--- a/src/main/java/com/assertthat/selenium_shutterbug/utils/web/Browser.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/utils/web/Browser.java
@@ -69,7 +69,13 @@ public class Browser {
             return ImageIO.read(srcFile);
         } catch (IOException e) {
             throw new UnableTakeSnapshotException(e);
-        }
+        } finally {
+	    // add this to clean up leaving this file in the temporary directory forever...
+	    if (scrFile.exists()) {
+	       srcFile.delete();
+	    }
+	}
+	
     }
 
     public BufferedImage takeScreenshotEntirePage() {


### PR DESCRIPTION
Update to Browser class to remove the temporary file that selenium takes in Browser.takeScreenshot().
