### PR TITLE
Unwrap wrapped drivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin
 .idea
 screenshots
 *main.java
+target

--- a/src/main/java/com/assertthat/selenium_shutterbug/utils/web/Browser.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/utils/web/Browser.java
@@ -15,7 +15,6 @@ import org.openqa.selenium.Point;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.remote.CommandInfo;
@@ -109,9 +108,7 @@ public class Browser {
      * @return BufferedImage resulting image
      */
     public BufferedImage takeScreenshotEntirePage() {
-        if (driver instanceof WrapsDriver) {
-            driver = ((WrapsDriver) this.driver).getWrappedDriver();
-        }
+        driver = unwrapDriver();
 
         if (driver instanceof ChromeDriver) {
             return takeScreenshotEntirePageUsingChromeCommand();
@@ -127,7 +124,22 @@ public class Browser {
         return takeScreenshotEntirePageDefault();
     }
 
-    public BufferedImage takeScreenshotEntirePageDefault() {
+    private WebDriver unwrapDriver() {
+        String[] wrapperClassNames = {"org.openqa.selenium.WrapsDriver", "org.openqa.selenium.internal.WrapsDriver"};
+        for (String wrapperClassName : wrapperClassNames) {
+            try {
+                Class<?> clazz = Class.forName(wrapperClassName);
+                if (clazz.isInstance(driver)) {
+                    return (WebDriver) clazz.getMethod("getWrappedDriver").invoke(driver);
+                }
+            } catch (ReflectiveOperationException e) {
+                // NOP
+            }
+        }
+        return driver;
+    }
+
+	public BufferedImage takeScreenshotEntirePageDefault() {
         final int _docWidth = this.getDocWidth();
         final int _docHeight = this.getDocHeight();
         BufferedImage combinedImage = new BufferedImage(_docWidth, _docHeight, BufferedImage.TYPE_INT_ARGB);

--- a/src/main/java/com/assertthat/selenium_shutterbug/utils/web/Browser.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/utils/web/Browser.java
@@ -15,6 +15,7 @@ import org.openqa.selenium.Point;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.remote.CommandInfo;
@@ -22,7 +23,6 @@ import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.Response;
 import org.openqa.selenium.remote.http.HttpMethod;
-import org.openqa.selenium.support.events.EventFiringWebDriver;
 
 import javax.imageio.ImageIO;
 import java.awt.*;
@@ -109,8 +109,8 @@ public class Browser {
      * @return BufferedImage resulting image
      */
     public BufferedImage takeScreenshotEntirePage() {
-        if (driver instanceof EventFiringWebDriver) {
-            driver = ((EventFiringWebDriver) this.driver).getWrappedDriver();
+        if (driver instanceof WrapsDriver) {
+            driver = ((WrapsDriver) this.driver).getWrappedDriver();
         }
 
         if (driver instanceof ChromeDriver) {


### PR DESCRIPTION
`EventFiringWebDriver` also implements `WrapsDriver`, which is more general and should be implemented by all wrappers. This recently cause issues at https://github.com/retest/recheck-web/pull/277.

As soon as Selenium is updated, `org.openqa.selenium.internal.WrapsDriver` should be replaced by `org.openqa.selenium.WrapsDriver`. (Should be available as of Selenium v3.14.0, see https://github.com/SeleniumHQ/selenium/commit/3665dd7456d074137ce47309fcea5632c208b588#diff-c68b4f7410690a3e2973585f06af6b92.)