### PR TITLE
Update maven-javadoc-plugin to fix javadoc error with openjdk 11.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.3</version>
+                        <version>3.1.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
[Deployment of 0.9.3 failed due to javadoc error](https://travis-ci.org/assertthat/selenium-shutterbug/builds/566848946).

This problem has been fixed in maven-javadoc-plugin 3.1.0 ([MJAVADOC-580](https://issues.apache.org/jira/browse/MJAVADOC-580)).
