### PR TITLE
Added methods to capture element screenshot after scrolling into view vertically centered

### DIFF
--- a/src/main/java/com/assertthat/selenium_shutterbug/core/Shutterbug.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/core/Shutterbug.java
@@ -114,14 +114,14 @@ public class Shutterbug {
     }
 
     /**
-     * To be used when need to screenshot particular element.
+     * To be used when need to screenshot particular element by vertically centering it in viewport.
      *
      * @param driver  WebDriver instance
      * @param element WebElement instance to be screenshotted
      * @return ElementSnapshot instance
      */
     public static ElementSnapshot shootElementVerticallyCentered(WebDriver driver, WebElement element) {
-        return shootElementVerticallyCentered(driver,element,false,true);
+        return shootElementVerticallyCentered(driver,element,false);
     }
     
     /**
@@ -152,14 +152,15 @@ public class Shutterbug {
     }
     
     /**
-     * To be used when need to screenshot particular element.
+     * To be used when need to screenshot particular element by vertically centering it within viewport.
      *
      * @param driver  WebDriver instance
      * @param element WebElement instance to be screen shot
      * @param useDevicePixelRatio whether or not take into account device pixel ratio
+     * 
      * @return ElementSnapshot instance
      */
-    public static ElementSnapshot shootElementVerticallyCentered(WebDriver driver, WebElement element, boolean useDevicePixelRatio, boolean verticallyCentered) {
+    public static ElementSnapshot shootElementVerticallyCentered(WebDriver driver, WebElement element, boolean useDevicePixelRatio) {
         Browser browser = new Browser(driver, useDevicePixelRatio);
         ElementSnapshot elementSnapshot = new ElementSnapshot(driver, browser.getDevicePixelRatio());
         browser.scrollToElementVerticalCentered(element);

--- a/src/main/java/com/assertthat/selenium_shutterbug/core/Shutterbug.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/core/Shutterbug.java
@@ -120,6 +120,17 @@ public class Shutterbug {
      * @param element WebElement instance to be screenshotted
      * @return ElementSnapshot instance
      */
+    public static ElementSnapshot shootElementVerticallyCentered(WebDriver driver, WebElement element) {
+        return shootElementVerticallyCentered(driver,element,false,true);
+    }
+    
+    /**
+     * To be used when need to screenshot particular element.
+     *
+     * @param driver  WebDriver instance
+     * @param element WebElement instance to be screenshotted
+     * @return ElementSnapshot instance
+     */
     public static ElementSnapshot shootElement(WebDriver driver, WebElement element) {
         return shootElement(driver,element,false);
     }
@@ -136,6 +147,22 @@ public class Shutterbug {
         Browser browser = new Browser(driver, useDevicePixelRatio);
         ElementSnapshot elementSnapshot = new ElementSnapshot(driver, browser.getDevicePixelRatio());
         browser.scrollToElement(element);
+        elementSnapshot.setImage(browser.takeScreenshot(),browser.getBoundingClientRect(element));
+        return elementSnapshot;
+    }
+    
+    /**
+     * To be used when need to screenshot particular element.
+     *
+     * @param driver  WebDriver instance
+     * @param element WebElement instance to be screen shot
+     * @param useDevicePixelRatio whether or not take into account device pixel ratio
+     * @return ElementSnapshot instance
+     */
+    public static ElementSnapshot shootElementVerticallyCentered(WebDriver driver, WebElement element, boolean useDevicePixelRatio, boolean verticallyCentered) {
+        Browser browser = new Browser(driver, useDevicePixelRatio);
+        ElementSnapshot elementSnapshot = new ElementSnapshot(driver, browser.getDevicePixelRatio());
+        browser.scrollToElementVerticalCentered(element);
         elementSnapshot.setImage(browser.takeScreenshot(),browser.getBoundingClientRect(element));
         return elementSnapshot;
     }

--- a/src/main/java/com/assertthat/selenium_shutterbug/utils/web/Browser.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/utils/web/Browser.java
@@ -47,6 +47,7 @@ public class Browser {
     private static final String VIEWPORT_WIDTH_JS = "js/viewport-width.js";
     private static final String SCROLL_TO_JS = "js/scroll-to.js";
     private static final String SCROLL_INTO_VIEW_JS = "js/scroll-element-into-view.js";
+    private static final String SCROLL_INTO_VIEW_VERTICAL_CENTERED_JS = "js/scroll-element-into-view-vertical-centered.js";
     private static final String CURRENT_SCROLL_Y_JS = "js/get-current-scrollY.js";
     private static final String CURRENT_SCROLL_X_JS = "js/get-current-scrollX.js";
     private static final String DEVICE_PIXEL_RATIO = "js/get-device-pixel-ratio.js";
@@ -256,6 +257,10 @@ public class Browser {
         executeJsScript(SCROLL_INTO_VIEW_JS, element);
     }
 
+    public void scrollToElementVerticalCentered(WebElement element) {
+    	executeJsScript(SCROLL_INTO_VIEW_VERTICAL_CENTERED_JS, element);
+    }
+    
     public void scrollTo(int x, int y) {
         executeJsScript(SCROLL_TO_JS, x / devicePixelRatio, y / devicePixelRatio);
     }

--- a/src/main/resources/js/scroll-element-into-view-vertical-centered.js
+++ b/src/main/resources/js/scroll-element-into-view-vertical-centered.js
@@ -1,0 +1,1 @@
+arguments[0].scrollIntoView({block: 'center'});


### PR DESCRIPTION
In instances where a page has a fixed navigation bar at the top, using scrollIntoView(true) can cause the element to be captured with the navigation bar in front of it. Javascript allows for elements to be vertically centered in most browsers using a scrollIntoViewOptions map. The code added allows for this functionality