### PR TITLE
Add method overload to equals with diff

### DIFF
--- a/src/main/java/com/assertthat/selenium_shutterbug/core/Snapshot.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/core/Snapshot.java
@@ -277,8 +277,7 @@ public abstract class Snapshot<T extends Snapshot> {
      * @return true if the the provided image and current image are strictly equal.
      */
     public boolean equalsWithDiff(BufferedImage image, String resultingImagePath) {
-        if (this.getImage() == image) return true;
-        return getImage() != null ? ImageProcessor.imagesAreEqualsWithDiff(getImage(), image, resultingImagePath, 0) : image == null;
+        return equalsWithDiff(image, resultingImagePath,0);
     }
 
     /**
@@ -298,8 +297,7 @@ public abstract class Snapshot<T extends Snapshot> {
      * @return true if the the provided image and current image are strictly equal.
      */
     public boolean equalsWithDiff(Snapshot image, String resultingImagePath) {
-        if (this == image) return true;
-        return getImage() != null ? ImageProcessor.imagesAreEqualsWithDiff(getImage(), image.getImage(),resultingImagePath, 0) : image == null;
+        return equalsWithDiff(image, resultingImagePath,0);
     }
 
     /**

--- a/src/main/java/com/assertthat/selenium_shutterbug/core/Snapshot.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/core/Snapshot.java
@@ -2,7 +2,7 @@
  *  Copyright (c) 2016, Glib Briia  <a href="mailto:glib.briia@assertthat.com">Glib Briia</a>
  *  Distributed under the terms of the MIT License
  */
-
+//haven't started on the method overload
 package com.assertthat.selenium_shutterbug.core;
 
 import com.assertthat.selenium_shutterbug.utils.file.FileUtil;

--- a/src/main/java/com/assertthat/selenium_shutterbug/core/Snapshot.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/core/Snapshot.java
@@ -2,7 +2,7 @@
  *  Copyright (c) 2016, Glib Briia  <a href="mailto:glib.briia@assertthat.com">Glib Briia</a>
  *  Distributed under the terms of the MIT License
  */
-//haven't started on the method overload
+
 package com.assertthat.selenium_shutterbug.core;
 
 import com.assertthat.selenium_shutterbug.utils.file.FileUtil;


### PR DESCRIPTION
Though a small thing, you may want to simplify the equalsWithDiff method by adding method overload like this.