### PR TITLE
Set awt headless by default

### DIFF
--- a/src/main/java/com/assertthat/selenium_shutterbug/core/Configurations.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/core/Configurations.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2016, Glib Briia  <a href="mailto:glib.briia@assertthat.com">Glib Briia</a>
+ *  Distributed under the terms of the MIT License
+ */
+
+package com.assertthat.selenium_shutterbug.core;
+
+import com.assertthat.selenium_shutterbug.utils.web.Browser;
+import com.assertthat.selenium_shutterbug.utils.web.Coordinates;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+
+import java.util.function.Function;
+
+public class Configurations {
+    /**
+     * by default Shutterbug sets java.awt.headless=true
+     * to avoid exception "Could not initialize class sun.awt.X11GraphicsEnvironment"
+     * Method is to delete already set property
+     */
+    public Configurations headless(boolean isHeadless) {
+        if (!isHeadless) {
+            System.clearProperty("java.awt.headless");
+        }
+        return this;
+    }
+}

--- a/src/main/java/com/assertthat/selenium_shutterbug/core/Shutterbug.java
+++ b/src/main/java/com/assertthat/selenium_shutterbug/core/Shutterbug.java
@@ -27,6 +27,10 @@ public class Shutterbug {
 
     }
 
+    static {
+        System.setProperty("java.awt.headless", "true");
+    }
+
     /**
      * Make screenshot of the viewport only.
      * To be used when screenshotting the page
@@ -451,5 +455,9 @@ public class Shutterbug {
     public static PageSnapshot shootFrame(WebDriver driver, String frameId) {
         WebElement frame = driver.findElement(By.id(frameId));
         return shootFrame(driver, frame, CaptureElement.VIEWPORT, true);
+    }
+
+    public static Configurations configure() {
+        return new Configurations();
     }
 }


### PR DESCRIPTION
Here is couple of concerns:
1. Setting headless property by default. On the one hand we let users to not write `headless()` each time they face the issue `Could not initialize class sun.awt.X11GraphicsEnvironment`, on the other - there are can be users which have AWT in their project and they don't need to be headless and they will be struggling to seek the cause.  So here is the choice between having issue and write `headless` each time or having issue and seek of it and write `headless(false)`. My opinion having property by default will be better for bigger amount of users. 
2. Coding. The way it is done right now will require to write 2 lines like
```
Shutterbug.configure().headless(false);
Shutterbug.shootPage(driver).save();
```
Another way of implementing this is having Singleton of Shuttebug class and return the instance of it. 
in this case it is possible to write like `Shutterbug.headless(false).shootPage(driver);`, but we will call static methods on instance, which is 😩 you know. 